### PR TITLE
Implement in-game editor

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -71,6 +71,11 @@ class StormEngine(ConanFile):
             else:
                 self.__install_bin("mimalloc.dll")
 
+            self.__copy_imgui_binding("imgui_impl_sdl2.cpp")
+            self.__copy_imgui_binding("imgui_impl_sdl2.h")
+            self.__copy_imgui_binding("imgui_impl_dx9.cpp")
+            self.__copy_imgui_binding("imgui_impl_dx9.h")
+
         else: # not Windows
             if self.settings.build_type == "Debug":
                 self.__install_lib("libfmodL.so.13")
@@ -115,3 +120,6 @@ class StormEngine(ConanFile):
 
     def __install_folder(self, src, dst):
         copy_tree(self.recipe_folder + src, self.__dest + dst)
+
+    def __copy_imgui_binding(self, name):
+        self.copy(name, dst=str(self.options.output_directory) + "/imgui", src="res/bindings")

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,5 +1,5 @@
 from conans import ConanFile, tools
-from os import getenv, path
+from os import getenv
 from random import getrandbits
 from distutils.dir_util import copy_tree
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -19,6 +19,7 @@ class StormEngine(ConanFile):
     # conan-center
     requires = ["zlib/1.2.13", "spdlog/1.9.2", "fast_float/3.4.0", "mimalloc/2.0.3", "sentry-native/0.6.5", "tomlplusplus/3.3.0", "nlohmann_json/3.11.2",
     "imgui/1.90-docking",
+    "cli11/2.3.2",
     # storm.jfrog.io
     "directx/9.0@storm/prebuilt", "fmod/2.02.05@storm/prebuilt"]
     # aux dependencies (e.g. for tests)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,5 +1,5 @@
 from conans import ConanFile, tools
-from os import getenv
+from os import getenv, path
 from random import getrandbits
 from distutils.dir_util import copy_tree
 
@@ -18,6 +18,7 @@ class StormEngine(ConanFile):
     # dependencies used in deploy binaries
     # conan-center
     requires = ["zlib/1.2.13", "spdlog/1.9.2", "fast_float/3.4.0", "mimalloc/2.0.3", "sentry-native/0.6.5", "tomlplusplus/3.3.0", "nlohmann_json/3.11.2",
+    "imgui/1.90-docking",
     # storm.jfrog.io
     "directx/9.0@storm/prebuilt", "fmod/2.02.05@storm/prebuilt"]
     # aux dependencies (e.g. for tests)

--- a/conanfile.py
+++ b/conanfile.py
@@ -53,6 +53,12 @@ class StormEngine(ConanFile):
         self.__install_folder("/src/techniques", "/resource/techniques")
         self.__install_folder("/src/libs/shared_headers/include/shared", "/resource/shared")
 
+        self.__copy_imgui_binding("imgui_impl_sdl2.cpp")
+        self.__copy_imgui_binding("imgui_impl_sdl2.h")
+        if self.settings.os == "Windows":
+            self.__copy_imgui_binding("imgui_impl_dx9.cpp")
+            self.__copy_imgui_binding("imgui_impl_dx9.h")
+
         if self.settings.os == "Windows":
             if self.settings.build_type == "Debug":
                 self.__install_lib("fmodL.dll")
@@ -70,11 +76,6 @@ class StormEngine(ConanFile):
                 self.__install_bin("mimalloc-debug.dll")
             else:
                 self.__install_bin("mimalloc.dll")
-
-            self.__copy_imgui_binding("imgui_impl_sdl2.cpp")
-            self.__copy_imgui_binding("imgui_impl_sdl2.h")
-            self.__copy_imgui_binding("imgui_impl_dx9.cpp")
-            self.__copy_imgui_binding("imgui_impl_dx9.h")
 
         else: # not Windows
             if self.settings.build_type == "Debug":

--- a/src/apps/engine/CMakeLists.txt
+++ b/src/apps/engine/CMakeLists.txt
@@ -34,6 +34,7 @@ STORM_SETUP(
     sentry-native
     ${SDL2_LIBRARIES}
     zlib
+    cli11
 
     # system
     ${SYSTEM_DEPS}

--- a/src/apps/engine/src/main.cpp
+++ b/src/apps/engine/src/main.cpp
@@ -4,6 +4,7 @@
 #include <mimalloc-new-delete.h>
 #include <mimalloc.h>
 #include <spdlog/spdlog.h>
+#include <CLI/CLI.hpp>
 
 #include "core_private.h"
 #include "fs.h"
@@ -120,6 +121,20 @@ void HandleWindowEvent(const storm::OSWindow::Event &event)
 
 int main(int argc, char *argv[])
 {
+    CLI::App app("Storm Engine");
+
+    bool enable_editor = false;
+    app.add_flag("--editor", enable_editor, "Enable in-game editor");
+
+    try
+    {
+        app.parse(argc, argv);
+    }
+    catch (const CLI::ParseError &e)
+    {
+        return app.exit(e);
+    }
+
     // Prevent multiple instances
 #ifdef _WIN32 // CreateEventA
     if (!CreateEventA(nullptr, false, false, "Global\\FBBD2286-A9F1-4303-B60C-743C3D7AA7BE") ||
@@ -171,6 +186,7 @@ int main(int argc, char *argv[])
 
     // Init core
     core_private = static_cast<CorePrivate *>(&core);
+    core_private->EnableEditor(enable_editor);
     core_private->Init();
 
     // Read config

--- a/src/apps/engine/src/main.cpp
+++ b/src/apps/engine/src/main.cpp
@@ -6,12 +6,12 @@
 #include <spdlog/spdlog.h>
 
 #include "core_private.h"
+#include "fs.h"
 #include "lifecycle_diagnostics_service.hpp"
 #include "logging.hpp"
 #include "os_window.hpp"
 #include "steam_api.hpp"
 #include "v_sound_service.h"
-#include "fs.h"
 #include "watermark.hpp"
 
 namespace
@@ -235,8 +235,13 @@ int main(int argc, char *argv[])
     isRunning = true;
     while (isRunning)
     {
-        SDL_PumpEvents();
-        SDL_FlushEvents(0, SDL_LASTEVENT);
+        SDL_Event event{};
+        while (SDL_PollEvent(&event) )
+        {
+            if (auto *editor = core.GetEditor(); editor != nullptr) {
+                editor->ProcessEvent(event);
+            }
+        }
 
         if (bActive || run_in_background)
         {

--- a/src/libs/core/CMakeLists.txt
+++ b/src/libs/core/CMakeLists.txt
@@ -1,5 +1,5 @@
 STORM_SETUP(
     TARGET_NAME core
     TYPE library
-    DEPENDENCIES diagnostics math shared_headers steam_api fast_float ${SDL2_LIBRARIES} window tomlplusplus nlohmann_json
+    DEPENDENCIES diagnostics editor math shared_headers steam_api fast_float ${SDL2_LIBRARIES} window tomlplusplus nlohmann_json
 )

--- a/src/libs/core/include/core.h
+++ b/src/libs/core/include/core.h
@@ -14,6 +14,8 @@
 #include "v_data.h"
 #include "v_file_service.h"
 
+#include <storm/editor/engine_editor.hpp>
+
 struct IFUNCINFO;
 
 struct ScreenSize
@@ -50,6 +52,8 @@ class Core
 {
   public:
     virtual ~Core() = default;
+
+    virtual void InitializeEditor(IDirect3DDevice9 *device) = 0;
 
     // return application window
     virtual storm::OSWindow *GetWindow() = 0;
@@ -130,6 +134,8 @@ class Core
     virtual hash_t GetClassCode(entid_t id) const = 0;
     virtual bool IsLayerFrozen(layer_index_t index) const = 0;
     virtual void ForEachEntity(const std::function<void(entptr_t)> &f) = 0;
+
+    [[nodiscard]] virtual storm::editor::EngineEditor *GetEditor() = 0;
 
     CONTROLS *Controls{};
 };

--- a/src/libs/core/include/core.h
+++ b/src/libs/core/include/core.h
@@ -54,6 +54,7 @@ class Core
     virtual ~Core() = default;
 
     virtual void InitializeEditor(IDirect3DDevice9 *device) = 0;
+    virtual bool IsEditorEnabled() = 0;
 
     // return application window
     virtual storm::OSWindow *GetWindow() = 0;

--- a/src/libs/core/include/core_private.h
+++ b/src/libs/core/include/core_private.h
@@ -21,4 +21,6 @@ public:
     virtual void collectCrashInfo() const = 0;
 
     virtual void SetWindow(std::shared_ptr<storm::OSWindow> window) = 0;
+
+    virtual void EnableEditor(bool enable) = 0;
 };

--- a/src/libs/core/include/entity.h
+++ b/src/libs/core/include/entity.h
@@ -68,6 +68,8 @@ class Entity
         return {};
     }
 
+    virtual void ShowEditor();
+
   private:
     EntitySelfData data_{};
 };

--- a/src/libs/core/src/core_impl.cpp
+++ b/src/libs/core/src/core_impl.cpp
@@ -318,9 +318,7 @@ void CoreImpl::ProcessEngineIniFile()
 
             if (iScriptVersion != ENGINE_SCRIPT_VERSION)
             {
-#ifdef _WIN32 // FIX_LINUX Cursor
-                ShowCursor(true);
-#endif
+                GetWindow()->ShowCursor(true);
                 SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Error", "Wrong script version", nullptr);
                 Compiler->ExitProgram();
             }

--- a/src/libs/core/src/core_impl.cpp
+++ b/src/libs/core/src/core_impl.cpp
@@ -119,6 +119,10 @@ void CoreImpl::Init()
     SetLayerType(EDITOR_REALIZE, layer_type_t::realize);
     SetLayerType(INFO_REALIZE, layer_type_t::realize);
     SetLayerType(SOUND_DEBUG_REALIZE, layer_type_t::realize);
+
+    storm::editor::EngineEditor::RegisterEditorTool("Entities", [this] (bool &active) {
+        entity_manager_.ShowEditor(active);
+    });
 }
 
 void CoreImpl::InitializeEditor(IDirect3DDevice9 *device)

--- a/src/libs/core/src/core_impl.cpp
+++ b/src/libs/core/src/core_impl.cpp
@@ -130,6 +130,16 @@ void CoreImpl::InitializeEditor(IDirect3DDevice9 *device)
     editor_ = std::make_unique<storm::editor::EngineEditor>(GetWindow()->SDLHandle(), device);
 }
 
+bool CoreImpl::IsEditorEnabled()
+{
+    return isEditorEnabled_;
+}
+
+void CoreImpl::EnableEditor(bool enable)
+{
+    isEditorEnabled_ = enable;
+}
+
 void CoreImpl::InitBase()
 {
     LoadClassesTable();

--- a/src/libs/core/src/core_impl.cpp
+++ b/src/libs/core/src/core_impl.cpp
@@ -121,6 +121,11 @@ void CoreImpl::Init()
     SetLayerType(SOUND_DEBUG_REALIZE, layer_type_t::realize);
 }
 
+void CoreImpl::InitializeEditor(IDirect3DDevice9 *device)
+{
+    editor_ = std::make_unique<storm::editor::EngineEditor>(GetWindow()->SDLHandle(), device);
+}
+
 void CoreImpl::InitBase()
 {
     LoadClassesTable();
@@ -1020,6 +1025,11 @@ bool CoreImpl::IsLayerFrozen(layer_index_t index) const
 void CoreImpl::ForEachEntity(const std::function<void(entptr_t)> &f)
 {
     entity_manager_.ForEachEntity(f);
+}
+
+storm::editor::EngineEditor *CoreImpl::GetEditor()
+{
+    return editor_.get();
 }
 
 void CoreImpl::collectCrashInfo() const

--- a/src/libs/core/src/core_impl.h
+++ b/src/libs/core/src/core_impl.h
@@ -15,6 +15,8 @@ class CoreImpl final : public CorePrivate
   public:
     void Init() override;
     void InitializeEditor(IDirect3DDevice9 *device) override;
+    bool IsEditorEnabled() override;
+    void EnableEditor(bool enable) override;
 
     void InitBase() override;
     void ReleaseBase() override;
@@ -169,6 +171,7 @@ private:
     char gstring[MAX_PATH]{}; // general purpose string
     bool State_loading;
     bool bEnableTimeScale{};
+    bool isEditorEnabled_ = false;
 
     SERVICES_LIST Services_List; // list for subsequent calls RunStart/RunEnd service functions
 

--- a/src/libs/core/src/core_impl.h
+++ b/src/libs/core/src/core_impl.h
@@ -14,6 +14,7 @@ class CoreImpl final : public CorePrivate
 {
   public:
     void Init() override;
+    void InitializeEditor(IDirect3DDevice9 *device) override;
 
     void InitBase() override;
     void ReleaseBase() override;
@@ -133,6 +134,8 @@ class CoreImpl final : public CorePrivate
     bool IsLayerFrozen(layer_index_t index) const override;
     void ForEachEntity(const std::function<void(entptr_t)>& f) override;
 
+    storm::editor::EngineEditor *GetEditor() override;
+
     void collectCrashInfo() const override;
 
     [[nodiscard]] bool initialized() const override
@@ -150,6 +153,8 @@ private:
     void loadCompatibilitySettings(INIFILE &inifile);
 
     EntityManager entity_manager_;
+
+    std::unique_ptr<storm::editor::EngineEditor> editor_;
 
     storm::ENGINE_VERSION targetVersion_ = storm::ENGINE_VERSION::LATEST;
 

--- a/src/libs/core/src/entity.cpp
+++ b/src/libs/core/src/entity.cpp
@@ -1,0 +1,8 @@
+#include "entity.h"
+
+#include <imgui.h>
+
+void Entity::ShowEditor()
+{
+    ImGui::Text("Selected entity does not expose any properties");
+}

--- a/src/libs/core/src/entity_manager.cpp
+++ b/src/libs/core/src/entity_manager.cpp
@@ -13,6 +13,7 @@
 
 #include <chrono>
 #include <functional>
+#include <imgui.h>
 
 namespace
 {
@@ -485,4 +486,60 @@ void EntityManager::ForEachEntity(const std::function<void(entptr_t)> &f)
             }
         }
     });
+}
+
+void EntityManager::ShowEditor(bool &active)
+{
+    if (ImGui::Begin("Entities", &active, 0))
+    {
+        auto text = std::format("There are currently {} entities", entities_.size() - freeIndices_.size());
+        ImGui::Text(text.c_str());
+
+        if (ImGui::BeginTable("Entities", 2, ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable) )
+        {
+            ImGui::TableSetupColumn("ID", ImGuiTableColumnFlags_WidthFixed);
+            ImGui::TableSetupColumn("Class", ImGuiTableColumnFlags_WidthStretch);
+
+            ImGui::TableHeadersRow();
+
+            static std::vector<bool> selected;
+
+            selected.resize(entities_.size(), 0);
+            size_t i = 0;
+
+            std::ranges::for_each(entities_, [&](const EntityInternalData &data) {
+                if (data.state == kValid)
+                {
+                    ImGui::TableNextRow();
+                    ImGui::TableNextColumn();
+
+                    std::string label = std::to_string(data.id);
+                    if (ImGui::Selectable(label.c_str(), selected[i], ImGuiSelectableFlags_SpanAllColumns) )
+                    {
+                        selected[i] = !selected[i];
+                    }
+                    ++i;
+                    ImGui::TableNextColumn();
+
+                    VMA *pClass = nullptr;
+                    for (const auto &c : __STORM_CLASSES_REGISTRY)
+                    {
+                        if (c->GetHash() == data.hash)
+                        {
+                            pClass = c;
+                            break;
+                        }
+                    }
+                    if (pClass != nullptr)
+                    {
+                        ImGui::Text("%s", pClass->GetName());
+                    }
+                }
+            });
+
+            ImGui::EndTable();
+        }
+
+        ImGui::End();
+    }
 }

--- a/src/libs/core/src/entity_manager.cpp
+++ b/src/libs/core/src/entity_manager.cpp
@@ -495,17 +495,14 @@ void EntityManager::ShowEditor(bool &active)
         auto text = std::format("There are currently {} entities", entities_.size() - freeIndices_.size());
         ImGui::Text(text.c_str());
 
+        static entid_t selected_entity = invalid_entity;
+
         if (ImGui::BeginTable("Entities", 2, ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_Resizable | ImGuiTableFlags_Reorderable) )
         {
             ImGui::TableSetupColumn("ID", ImGuiTableColumnFlags_WidthFixed);
             ImGui::TableSetupColumn("Class", ImGuiTableColumnFlags_WidthStretch);
 
             ImGui::TableHeadersRow();
-
-            static std::vector<bool> selected;
-
-            selected.resize(entities_.size(), 0);
-            size_t i = 0;
 
             std::ranges::for_each(entities_, [&](const EntityInternalData &data) {
                 if (data.state == kValid)
@@ -514,11 +511,10 @@ void EntityManager::ShowEditor(bool &active)
                     ImGui::TableNextColumn();
 
                     std::string label = std::to_string(data.id);
-                    if (ImGui::Selectable(label.c_str(), selected[i], ImGuiSelectableFlags_SpanAllColumns) )
+                    if (ImGui::Selectable(label.c_str(), data.id == selected_entity, ImGuiSelectableFlags_SpanAllColumns) )
                     {
-                        selected[i] = !selected[i];
+                        selected_entity = data.id;
                     }
-                    ++i;
                     ImGui::TableNextColumn();
 
                     VMA *pClass = nullptr;
@@ -538,6 +534,16 @@ void EntityManager::ShowEditor(bool &active)
             });
 
             ImGui::EndTable();
+        }
+
+        if (ImGui::Begin("Entity Properties") )
+        {
+            Entity *entity = GetEntityPointer(selected_entity);
+            if (entity != nullptr)
+            {
+                entity->ShowEditor();
+            }
+            ImGui::End();
         }
 
         ImGui::End();

--- a/src/libs/core/src/entity_manager.h
+++ b/src/libs/core/src/entity_manager.h
@@ -34,6 +34,8 @@ class EntityManager final
     void NewLifecycle();
     void ForEachEntity(const std::function<void(entptr_t)> &f);
 
+    void ShowEditor(bool &active);
+
   private:
     constexpr static size_t kMaxLayerNum = sizeof(uint32_t) * 8;
 

--- a/src/libs/editor/CMakeLists.txt
+++ b/src/libs/editor/CMakeLists.txt
@@ -3,9 +3,12 @@ if (NOT WIN32)
 endif()
 
 add_library(imgui_backend STATIC
-    "${CONAN_SRC_DIRS_IMGUI}/imgui_impl_dx9.cpp"
     "${CONAN_SRC_DIRS_IMGUI}/imgui_impl_sdl2.cpp"
 )
+if (WIN32)
+    target_sources(imgui_backend PRIVATE "${CONAN_SRC_DIRS_IMGUI}/imgui_impl_dx9.cpp")
+endif()
+
 target_include_directories(imgui_backend PUBLIC ${CONAN_SRC_DIRS_IMGUI})
 target_link_libraries(imgui_backend PUBLIC imgui ${SDL2_LIBRARIES} ${SYSTEM_DEPS})
 

--- a/src/libs/editor/CMakeLists.txt
+++ b/src/libs/editor/CMakeLists.txt
@@ -1,0 +1,17 @@
+if (NOT WIN32)
+    set(SYSTEM_DEPS "${NATIVE_D3D9_LIBS}")
+endif()
+
+add_library(imgui_backend STATIC
+    "${CONAN_SRC_DIRS_IMGUI}/imgui_impl_dx9.cpp"
+    "${CONAN_SRC_DIRS_IMGUI}/imgui_impl_sdl2.cpp"
+)
+target_include_directories(imgui_backend PUBLIC ${CONAN_SRC_DIRS_IMGUI})
+target_link_libraries(imgui_backend PUBLIC imgui ${SDL2_LIBRARIES} ${SYSTEM_DEPS})
+
+STORM_SETUP(
+        TARGET_NAME editor
+        TYPE storm_module
+        DEPENDENCIES core imgui_backend
+        TEST_DEPENDENCIES catch2
+)

--- a/src/libs/editor/CMakeLists.txt
+++ b/src/libs/editor/CMakeLists.txt
@@ -2,7 +2,7 @@ if (NOT WIN32)
     set(SYSTEM_DEPS "${NATIVE_D3D9_LIBS}")
 endif()
 
-set(IMGUI_BINGINDS_DIR "${CONAN_IMGUI_ROOT}/res/bindings")
+set(IMGUI_BINGINDS_DIR "${CMAKE_BINARY_DIR}/imgui")
 
 add_library(imgui_backend STATIC
     "${IMGUI_BINGINDS_DIR}/imgui_impl_sdl2.cpp"

--- a/src/libs/editor/CMakeLists.txt
+++ b/src/libs/editor/CMakeLists.txt
@@ -2,11 +2,13 @@ if (NOT WIN32)
     set(SYSTEM_DEPS "${NATIVE_D3D9_LIBS}")
 endif()
 
+set(IMGUI_BINGINDS_DIR "${CONAN_IMGUI_ROOT}/res/bindings")
+
 add_library(imgui_backend STATIC
-    "${CONAN_SRC_DIRS_IMGUI}/imgui_impl_sdl2.cpp"
+    "${IMGUI_BINGINDS_DIR}/imgui_impl_sdl2.cpp"
 )
 if (WIN32)
-    target_sources(imgui_backend PRIVATE "${CONAN_SRC_DIRS_IMGUI}/imgui_impl_dx9.cpp")
+    target_sources(imgui_backend PRIVATE "${IMGUI_BINGINDS_DIR}/imgui_impl_dx9.cpp")
 endif()
 
 target_include_directories(imgui_backend PUBLIC ${CONAN_SRC_DIRS_IMGUI})

--- a/src/libs/editor/CMakeLists.txt
+++ b/src/libs/editor/CMakeLists.txt
@@ -11,7 +11,7 @@ if (WIN32)
     target_sources(imgui_backend PRIVATE "${IMGUI_BINGINDS_DIR}/imgui_impl_dx9.cpp")
 endif()
 
-target_include_directories(imgui_backend PUBLIC ${CONAN_SRC_DIRS_IMGUI})
+target_include_directories(imgui_backend PUBLIC ${IMGUI_BINGINDS_DIR})
 target_link_libraries(imgui_backend PUBLIC imgui ${SDL2_LIBRARIES} ${SYSTEM_DEPS})
 
 STORM_SETUP(

--- a/src/libs/editor/include/storm/editor/engine_editor.hpp
+++ b/src/libs/editor/include/storm/editor/engine_editor.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <functional>
 #include <memory>
+#include <string_view>
 
 struct SDL_Window;
 union SDL_Event;
@@ -18,6 +20,8 @@ enum class DebugFlag
     CannonDebug,
 };
 
+using EditorToolCallback = std::function<void(bool &active)>;
+
 class EngineEditor final
 {
   public:
@@ -32,6 +36,8 @@ class EngineEditor final
     bool IsFocused() const;
 
     bool IsDebugFlagEnabled(DebugFlag flag) const;
+
+    static void RegisterEditorTool(const std::string_view &title, EditorToolCallback callback);
 
   private:
     class Impl;

--- a/src/libs/editor/include/storm/editor/engine_editor.hpp
+++ b/src/libs/editor/include/storm/editor/engine_editor.hpp
@@ -9,6 +9,15 @@ struct IDirect3DDevice9;
 namespace storm::editor
 {
 
+enum class DebugFlag
+{
+    RenderWireframe,
+    SoundDebug,
+    LocationDebug,
+    ExtendedLocationDebug,
+    CannonDebug,
+};
+
 class EngineEditor final
 {
   public:
@@ -21,6 +30,8 @@ class EngineEditor final
     void ProcessEvent(SDL_Event &event);
 
     bool IsFocused() const;
+
+    bool IsDebugFlagEnabled(DebugFlag flag) const;
 
   private:
     class Impl;

--- a/src/libs/editor/include/storm/editor/engine_editor.hpp
+++ b/src/libs/editor/include/storm/editor/engine_editor.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <memory>
+
+struct SDL_Window;
+union SDL_Event;
+struct IDirect3DDevice9;
+
+namespace storm::editor
+{
+
+class EngineEditor final
+{
+  public:
+    explicit EngineEditor(SDL_Window *window, IDirect3DDevice9 *device);
+    ~EngineEditor();
+
+    void StartFrame();
+    void EndFrame();
+
+    void ProcessEvent(SDL_Event &event);
+
+    bool IsFocused() const;
+
+  private:
+    class Impl;
+
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace storm::editor

--- a/src/libs/editor/src/storm/editor/engine_editor.cpp
+++ b/src/libs/editor/src/storm/editor/engine_editor.cpp
@@ -4,6 +4,8 @@
 #include <imgui_impl_dx9.h>
 #include <imgui_impl_sdl2.h>
 
+#include <array>
+
 #ifdef WIN32
 #include <Windows.h>
 #endif WIN32
@@ -13,6 +15,8 @@ namespace storm::editor
 
 class EngineEditor::Impl final {
   public:
+    std::array<bool, 5> debugFlags_;
+
     ImGuiContext *imgui_;
 
     bool isFocused_ = true;
@@ -61,11 +65,22 @@ void EngineEditor::StartFrame()
 
         if (ImGui::BeginMenuBar() )
         {
-            if (ImGui::BeginMenu("Engine") )
+            if (ImGui::BeginMenu("Tools") )
             {
                 ImGui::MenuItem("Entities", NULL, &impl_->showEntityMenu_);
                 ImGui::EndMenu();
             }
+
+            if (ImGui::BeginMenu("Debug") )
+            {
+                ImGui::MenuItem("Wireframe mode", NULL, &impl_->debugFlags_[static_cast<size_t>(DebugFlag::RenderWireframe)]);
+                ImGui::MenuItem("Sound debug", NULL, &impl_->debugFlags_[static_cast<size_t>(DebugFlag::SoundDebug)]);
+                ImGui::MenuItem("Location debug", NULL, &impl_->debugFlags_[static_cast<size_t>(DebugFlag::LocationDebug)]);
+                ImGui::MenuItem("Extended location debug", NULL, &impl_->debugFlags_[static_cast<size_t>(DebugFlag::ExtendedLocationDebug)]);
+                ImGui::MenuItem("Ship cannon debug", NULL, &impl_->debugFlags_[static_cast<size_t>(DebugFlag::CannonDebug)]);
+                ImGui::EndMenu();
+            }
+
             ImGui::EndMenuBar();
         }
 
@@ -95,6 +110,11 @@ void EngineEditor::ProcessEvent(SDL_Event &event)
 bool EngineEditor::IsFocused() const
 {
     return impl_->isFocused_;
+}
+
+bool EngineEditor::IsDebugFlagEnabled(DebugFlag flag) const
+{
+    return impl_->debugFlags_[static_cast<size_t>(flag)];
 }
 
 } // namespace storm::editor

--- a/src/libs/editor/src/storm/editor/engine_editor.cpp
+++ b/src/libs/editor/src/storm/editor/engine_editor.cpp
@@ -1,0 +1,100 @@
+#include "storm/editor/engine_editor.hpp"
+
+#include <imgui.h>
+#include <imgui_impl_dx9.h>
+#include <imgui_impl_sdl2.h>
+
+#ifdef WIN32
+#include <Windows.h>
+#endif WIN32
+
+namespace storm::editor
+{
+
+class EngineEditor::Impl final {
+  public:
+    ImGuiContext *imgui_;
+
+    bool isFocused_ = true;
+    bool showEntityMenu_ = false;
+};
+
+EngineEditor::EngineEditor(SDL_Window *window, IDirect3DDevice9 *device)
+    : impl_(std::make_unique<Impl>())
+{
+    IMGUI_CHECKVERSION();
+    impl_->imgui_ = ImGui::CreateContext();
+    ImGuiIO &io = ImGui::GetIO();
+    io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+    io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
+
+    ImGui_ImplSDL2_InitForD3D(window);
+    ImGui_ImplDX9_Init(device);
+}
+
+EngineEditor::~EngineEditor()
+{
+    ImGui::DestroyContext(impl_->imgui_);
+}
+
+void EngineEditor::StartFrame()
+{
+    const auto &io = ImGui::GetIO();
+    const bool is_focused = io.WantCaptureKeyboard;
+    if (is_focused != impl_->isFocused_)
+    {
+#ifdef WIN32
+      ShowCursor(is_focused);
+#endif
+    }
+    impl_->isFocused_ =  is_focused;
+
+    ImGui_ImplDX9_NewFrame();
+    ImGui_ImplSDL2_NewFrame();
+    ImGui::NewFrame();
+    if (ImGui::Begin("Developer Tools", NULL, ImGuiWindowFlags_MenuBar) )
+    {
+        if (IsFocused() )
+        {
+            ImGui::Text("Game controls are disabled while using the editor");
+        }
+
+        if (ImGui::BeginMenuBar() )
+        {
+            if (ImGui::BeginMenu("Engine") )
+            {
+                ImGui::MenuItem("Entities", NULL, &impl_->showEntityMenu_);
+                ImGui::EndMenu();
+            }
+            ImGui::EndMenuBar();
+        }
+
+        if (impl_->showEntityMenu_) {
+            if (ImGui::Begin("Entities", &impl_->showEntityMenu_, 0) )
+            {
+                ImGui::Text("There are currently 6 entities");
+                ImGui::End();
+            }
+        }
+
+        ImGui::End();
+    }
+}
+
+void EngineEditor::EndFrame()
+{
+    ImGui::Render();
+    ImGui_ImplDX9_RenderDrawData(ImGui::GetDrawData());
+}
+
+void EngineEditor::ProcessEvent(SDL_Event &event)
+{
+    ImGui_ImplSDL2_ProcessEvent(&event);
+}
+
+bool EngineEditor::IsFocused() const
+{
+    return impl_->isFocused_;
+}
+
+} // namespace storm::editor

--- a/src/libs/editor/src/storm/editor/engine_editor.cpp
+++ b/src/libs/editor/src/storm/editor/engine_editor.cpp
@@ -1,5 +1,7 @@
 #include "storm/editor/engine_editor.hpp"
 
+#include "core.h"
+
 #include <imgui.h>
 #include <imgui_impl_dx9.h>
 #include <imgui_impl_sdl2.h>
@@ -54,14 +56,8 @@ EngineEditor::~EngineEditor()
 void EngineEditor::StartFrame()
 {
     const auto &io = ImGui::GetIO();
-    const bool is_focused = io.WantCaptureKeyboard;
-    if (is_focused != impl_->isFocused_)
-    {
-#ifdef WIN32
-      ShowCursor(is_focused);
-#endif
-    }
-    impl_->isFocused_ =  is_focused;
+    impl_->isFocused_ = io.WantCaptureKeyboard;
+    core.GetWindow()->ShowCursor(impl_->isFocused_);
 
     ImGui_ImplDX9_NewFrame();
     ImGui_ImplSDL2_NewFrame();

--- a/src/libs/editor/src/storm/editor/engine_editor.cpp
+++ b/src/libs/editor/src/storm/editor/engine_editor.cpp
@@ -3,13 +3,13 @@
 #include "core.h"
 
 #include <imgui.h>
-#include <imgui_impl_dx9.h>
 #include <imgui_impl_sdl2.h>
 
 #include <array>
 
 #ifdef WIN32
 #include <Windows.h>
+#include <imgui_impl_dx9.h>
 #endif WIN32
 
 namespace storm::editor
@@ -45,7 +45,9 @@ EngineEditor::EngineEditor(SDL_Window *window, IDirect3DDevice9 *device)
     io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
 
     ImGui_ImplSDL2_InitForD3D(window);
+#ifdef WIN32
     ImGui_ImplDX9_Init(device);
+#endif WIN32
 }
 
 EngineEditor::~EngineEditor()
@@ -59,7 +61,9 @@ void EngineEditor::StartFrame()
     impl_->isFocused_ = io.WantCaptureKeyboard;
     core.GetWindow()->ShowCursor(impl_->isFocused_);
 
+#ifdef WIN32
     ImGui_ImplDX9_NewFrame();
+#endif WIN32
     ImGui_ImplSDL2_NewFrame();
     ImGui::NewFrame();
     if (ImGui::Begin("Developer Tools", NULL, ImGuiWindowFlags_MenuBar) )
@@ -103,7 +107,9 @@ void EngineEditor::StartFrame()
 void EngineEditor::EndFrame()
 {
     ImGui::Render();
+#ifdef WIN32
     ImGui_ImplDX9_RenderDrawData(ImGui::GetDrawData());
+#endif WIN32
 }
 
 void EngineEditor::ProcessEvent(SDL_Event &event)

--- a/src/libs/location/src/location.cpp
+++ b/src/libs/location/src/location.cpp
@@ -1010,12 +1010,14 @@ void Location::CreateSphere()
 
 bool Location::IsExDebugView()
 {
-    return core.Controls->GetDebugAsyncKeyState('O') < 0;
+    const auto *editor = core.GetEditor();
+    return editor != nullptr && editor->IsDebugFlagEnabled(storm::editor::DebugFlag::ExtendedLocationDebug);
 }
 
 bool Location::IsDebugView()
 {
-    return core.Controls->GetDebugAsyncKeyState('G') < 0 || core.Controls->GetDebugAsyncKeyState('O') < 0;
+    const auto *editor = core.GetEditor();
+    return editor != nullptr && editor->IsDebugFlagEnabled(storm::editor::DebugFlag::LocationDebug) || editor->IsDebugFlagEnabled(storm::editor::DebugFlag::ExtendedLocationDebug);
 }
 
 // Write text

--- a/src/libs/pcs_controls/src/pcs_controls.cpp
+++ b/src/libs/pcs_controls/src/pcs_controls.cpp
@@ -434,9 +434,17 @@ bool PCS_CONTROLS::GetControlState(int32_t control_code, CONTROL_STATE &_state_s
 
 void PCS_CONTROLS::Update(uint32_t DeltaTime)
 {
+    if (auto *editor = core.GetEditor(); editor != nullptr && editor->IsFocused()) {
+        // Skip control processing
+        nMouseDx = 0;
+        nMouseDy = 0;
+        return;
+    }
+
 #ifdef _WIN32
     static int nMouseXPrev, nMouseYPrev;
-    if (updateCursor_) {
+    if (updateCursor_)
+    {
         POINT point;
         GetCursorPos(&point);
 
@@ -449,7 +457,8 @@ void PCS_CONTROLS::Update(uint32_t DeltaTime)
         nMouseYPrev = r.top + (r.bottom - r.top) / 2;
         SetCursorPos(nMouseXPrev, nMouseYPrev);
     }
-    else {
+    else
+    {
         nMouseDx = 0;
         nMouseDy = 0;
     }

--- a/src/libs/renderer/src/s_device.cpp
+++ b/src/libs/renderer/src/s_device.cpp
@@ -13,7 +13,6 @@
 #include "v_s_stack.h"
 
 #include <fmt/chrono.h>
-#include <imgui_impl_dx9.h>
 #include <SDL_timer.h>
 
 #include <algorithm>

--- a/src/libs/renderer/src/s_device.cpp
+++ b/src/libs/renderer/src/s_device.cpp
@@ -806,7 +806,10 @@ bool DX9RENDER::InitDevice(bool windowed, HWND _hwnd, int32_t width, int32_t hei
     effects_.setDevice(d3d9);
 #endif
 
-    core.InitializeEditor(d3d9);
+    if (core.IsEditorEnabled() )
+    {
+        core.InitializeEditor(d3d9);
+    }
 
     // Create render targets for POST PROCESS effects
     d3d9->GetRenderTarget(0, &pOriginalScreenSurface);

--- a/src/libs/renderer/src/s_device.cpp
+++ b/src/libs/renderer/src/s_device.cpp
@@ -2743,7 +2743,9 @@ void DX9RENDER::RunStart()
     dwNumLI = 0;
     BeginScene();
 
-    if (auto *editor = core.GetEditor(); editor != nullptr) {
+    auto *editor = core.GetEditor();
+
+    if (editor != nullptr) {
         editor->StartFrame();
     }
 
@@ -2766,8 +2768,10 @@ void DX9RENDER::RunStart()
         InvokeEntitiesRestoreRender();
     }
 
-    SetRenderState(D3DRS_FILLMODE, (core.Controls->GetDebugAsyncKeyState('F') < 0) ? D3DFILL_WIREFRAME : D3DFILL_SOLID);
-    // SetRenderState(D3DRS_FILLMODE, D3DFILL_SOLID); eddy
+    SetRenderState(D3DRS_FILLMODE,
+                   (editor != nullptr && editor->IsDebugFlagEnabled(storm::editor::DebugFlag::RenderWireframe))
+                       ? D3DFILL_WIREFRAME
+                       : D3DFILL_SOLID);
 
     PlayToTexture();
 

--- a/src/libs/renderer/src/s_device.cpp
+++ b/src/libs/renderer/src/s_device.cpp
@@ -12,10 +12,12 @@
 #include "texture.h"
 #include "v_s_stack.h"
 
-#include <SDL_timer.h>
-#include <algorithm>
-
 #include <fmt/chrono.h>
+#include <imgui_impl_dx9.h>
+#include <SDL_timer.h>
+
+#include <algorithm>
+#include <imgui_impl_sdl2.h>
 
 #ifdef _WIN32
 #include <DxErr.h>
@@ -804,6 +806,8 @@ bool DX9RENDER::InitDevice(bool windowed, HWND _hwnd, int32_t width, int32_t hei
     effects_.setDevice(d3d9);
 #endif
 
+    core.InitializeEditor(d3d9);
+
     // Create render targets for POST PROCESS effects
     d3d9->GetRenderTarget(0, &pOriginalScreenSurface);
     d3d9->GetDepthStencilSurface(&pOriginalDepthSurface);
@@ -1256,6 +1260,10 @@ bool DX9RENDER::DX9EndScene()
 
     if (CHECKD3DERR(EndScene()))
         return false;
+
+    if (auto *editor = core.GetEditor(); editor != nullptr) {
+        editor->EndFrame();
+    }
 
     if (bMakeShoot)
         MakeScreenShot();
@@ -2734,6 +2742,10 @@ void DX9RENDER::RunStart()
     dwNumLV = 0;
     dwNumLI = 0;
     BeginScene();
+
+    if (auto *editor = core.GetEditor(); editor != nullptr) {
+        editor->StartFrame();
+    }
 
     //------------------------------------------
     bInsideScene = true;

--- a/src/libs/sea/src/sea.cpp
+++ b/src/libs/sea/src/sea.cpp
@@ -6,11 +6,13 @@
 
 #include "core.h"
 #include "math3d.h"
-#include "sse.h"
 #include "math_inlines.h"
 #include "shared/sea_ai/script_defines.h"
+#include "sse.h"
 #include "tga.h"
 #include "v_file_service.h"
+
+#include <imgui.h>
 
 using storm::Sqr;
 
@@ -2027,4 +2029,38 @@ void SEA::RestoreRender()
     rs->CreateTexture(128, 128, 1, D3DUSAGE_RENDERTARGET, D3DFMT_R5G6B5, D3DPOOL_DEFAULT, &pReflection);
     rs->CreateTexture(128, 128, 1, D3DUSAGE_RENDERTARGET, D3DFMT_R5G6B5, D3DPOOL_DEFAULT, &pReflectionSunroad);
     rs->CreateDepthStencilSurface(128, 128, D3DFMT_D24S8, D3DMULTISAMPLE_NONE, &pReflectionSurfaceDepth);
+}
+
+void SEA::ShowEditor()
+{
+    ImGui::Text("Sea");
+    ImGui::DragFloat("Fresnel", &fFrenel, 0.005f, 0.0f, 1.0f, "%.3f");
+    ImGui::DragFloat("Attenuation", &v4SeaParameters.x, 0.005f, 0.0f, 1.0f, "%.3f");
+    ImGui::DragFloat("Reflection", &v4SeaParameters.y, 0.005f, 0.0f, 1.0f, "%.3f");
+    ImGui::DragFloat("Transparency", &v4SeaParameters.z, 0.005f, 0.0f, 1.0f, "%.3f");
+    ImGui::DragFloat("Max Sea Height", &fMaxSeaHeight, 0.005f, 0.0f, 1.0f, "%.3f");
+    ImGui::DragFloat("Max Sea Distance", &fMaxSeaDistance, 0.005f, 0.0f, 1.0f, "%.3f");
+    ImGui::DragFloat("Bump Scale", &fBumpScale, 0.005f, 0.0f, 1.0f, "%.3f");
+    ImGui::DragFloat("Bump Speed", &fBumpSpeed, 0.005f, 0.0f, 1.0f, "%.3f");
+
+    ImGui::ColorEdit4("Sea Color", (float*)&v4SeaColor, ImGuiColorEditFlags_NoInputs);
+    ImGui::ColorEdit4("Sky Color", (float*)&v4SkyColor, ImGuiColorEditFlags_NoInputs);
+
+    ImGui::DragFloat("Scale 1", &fScale1, 0.005f, 0.0f, 1.0f, "%.3f");
+    ImGui::DragFloat("Amplitude 1", &fAmp1, 0.005f, 0.0f, 1.0f, "%.3f");
+    ImGui::DragFloat("Animation Speed 1", &fAnimSpeed1, 0.005f, 0.0f, 1.0f, "%.3f");
+    float movement_speed_1[3] = {vMoveSpeed1.x, vMoveSpeed1.y, vMoveSpeed1.z};
+    ImGui::DragFloat3("Movement Speed 1", movement_speed_1, 0.005f, 0.0f, 1.0f, "%.3f");
+    vMoveSpeed1.x = movement_speed_1[0];
+    vMoveSpeed1.y = movement_speed_1[1];
+    vMoveSpeed1.z = movement_speed_1[2];
+
+    ImGui::DragFloat("Scale 2", &fScale2, 0.005f, 0.0f, 1.0f, "%.3f");
+    ImGui::DragFloat("Amplitude 2", &fAmp2, 0.005f, 0.0f, 1.0f, "%.3f");
+    ImGui::DragFloat("Animation Speed 2", &fAnimSpeed2, 0.005f, 0.0f, 1.0f, "%.3f");
+    float movement_speed_2[3] = {vMoveSpeed2.x, vMoveSpeed2.y, vMoveSpeed2.z};
+    ImGui::DragFloat3("Movement Speed 2", movement_speed_2, 0.005f, 0.0f, 1.0f, "%.3f");
+    vMoveSpeed2.x = movement_speed_2[0];
+    vMoveSpeed2.y = movement_speed_2[1];
+    vMoveSpeed2.z = movement_speed_2[2];
 }

--- a/src/libs/sea/src/sea.h
+++ b/src/libs/sea/src/sea.h
@@ -9,7 +9,7 @@
 #include "vma.hpp"
 
 
-class SEA : public SEA_BASE
+class SEA final : public SEA_BASE
 {
   private:
     // uint32_t dwSkyCode = MakeHashValue("sky");
@@ -228,4 +228,6 @@ class SEA : public SEA_BASE
 
     void LostRender();
     void RestoreRender();
+
+    void ShowEditor() override;
 };

--- a/src/libs/sea_ai/src/ai_ship_cannon_controller.cpp
+++ b/src/libs/sea_ai/src/ai_ship_cannon_controller.cpp
@@ -555,11 +555,8 @@ void AIShipCannonController::Realize(float fDeltaTime)
 {
     using namespace std::chrono_literals;
 
-    if (core.Controls->GetDebugAsyncKeyState('H') < 0)
-    {
-        debugDrawToggle = !debugDrawToggle;
-        std::this_thread::sleep_for(100ms);
-    }
+    const auto *editor = core.GetEditor();
+    debugDrawToggle = editor != nullptr && editor->IsDebugFlagEnabled(storm::editor::DebugFlag::CannonDebug);
 
     if (!debugDrawToggle)
     {

--- a/src/libs/sound_service/src/sound_service.cpp
+++ b/src/libs/sound_service/src/sound_service.cpp
@@ -1115,11 +1115,8 @@ void SoundService::CreateEntityIfNeed()
 
 void SoundService::DebugDraw()
 {
-    if (core.Controls->GetDebugAsyncKeyState('J') < 0)
-    {
-        bShowDebugInfo = !bShowDebugInfo;
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    }
+    const auto *editor = core.GetEditor();
+    bShowDebugInfo = editor != nullptr && editor->IsDebugFlagEnabled(storm::editor::DebugFlag::SoundDebug);
 
     if (!bShowDebugInfo)
         return;

--- a/src/libs/window/include/os_window.hpp
+++ b/src/libs/window/include/os_window.hpp
@@ -64,6 +64,8 @@ class OSWindow
     //! Set window gamma
     virtual void SetGamma(const uint16_t (&red)[256], const uint16_t (&green)[256], const uint16_t (&blue)[256]) = 0;
 
+    virtual void ShowCursor(bool show_cursor) = 0;
+
     //! Subscribe for events
     //! \param handler event callback
     //! \return subscription id, which should be passed to unsubscribe()

--- a/src/libs/window/include/os_window.hpp
+++ b/src/libs/window/include/os_window.hpp
@@ -4,6 +4,8 @@
 #include <memory>
 #include <string>
 
+struct SDL_Window;
+
 namespace storm
 {
 struct WindowSize
@@ -72,6 +74,7 @@ class OSWindow
 
     //! Os-depended window handler (i.e. HWND on Windows)
     virtual void *OSHandle() = 0;
+    virtual SDL_Window *SDLHandle() const = 0;
 
     //! Create new window
     static std::shared_ptr<OSWindow> Create(int width, int height, int preferred_display, bool fullscreen,

--- a/src/libs/window/src/sdl_window.cpp
+++ b/src/libs/window/src/sdl_window.cpp
@@ -98,6 +98,17 @@ void SDLWindow::SetGamma(const uint16_t (&red)[256], const uint16_t (&green)[256
     SDL_SetWindowGammaRamp(window_.get(), red, green, blue);
 }
 
+void SDLWindow::ShowCursor(bool show_cursor)
+{
+    if (show_cursor != isCursorShown_)
+    {
+        isCursorShown_ = show_cursor;
+#ifdef _WIN32 // FIX_LINUX Cursor
+        ::ShowCursor(show_cursor);
+#endif
+    }
+}
+
 int SDLWindow::Subscribe(const EventHandler &handler)
 {
     int id = 1;

--- a/src/libs/window/src/sdl_window.hpp
+++ b/src/libs/window/src/sdl_window.hpp
@@ -32,8 +32,8 @@ class SDLWindow : public OSWindow
     void Unsubscribe(int id) override;
 
     void *OSHandle() override;
+    SDL_Window *SDLHandle() const override;
 
-    SDL_Window *SDLHandle() const;
     void ProcessEvent(const SDL_WindowEvent &evt) const;
 
   private:

--- a/src/libs/window/src/sdl_window.hpp
+++ b/src/libs/window/src/sdl_window.hpp
@@ -27,6 +27,7 @@ class SDLWindow : public OSWindow
     void WarpMouseInWindow(int x, int y) override;
     void SetTitle(const std::string &title) override;
     void SetGamma(const uint16_t (&red)[256], const uint16_t (&green)[256], const uint16_t (&blue)[256]) override;
+    void ShowCursor(bool show_cursor) override;
 
     int Subscribe(const EventHandler &handler) override;
     void Unsubscribe(int id) override;
@@ -39,9 +40,10 @@ class SDLWindow : public OSWindow
   private:
     static int SDLCALL SDLEventHandler(void *userdata, SDL_Event *evt);
 
+    std::map<int, EventHandler> handlers_;
     std::unique_ptr<SDL_Window, std::function<void(SDL_Window *)>> window_ = nullptr;
     uint32_t sdlID_;
     bool fullscreen_ = false;
-    std::map<int, EventHandler> handlers_;
+    bool isCursorShown_ = true;
 };
 } // namespace storm

--- a/src/libs/xinterface/src/xinterface.cpp
+++ b/src/libs/xinterface/src/xinterface.cpp
@@ -1169,7 +1169,12 @@ void XINTERFACE::LoadIni()
     vMouse[2].tu = vMouse[3].tu = 1.f;
     vMouse[0].tv = vMouse[2].tv = 0.f;
     vMouse[1].tv = vMouse[3].tv = 1.f;
-
+#ifdef _WIN32 // FIX_LINUX Cursor
+    if (auto *editor = core.GetEditor(); editor == nullptr || !editor->IsFocused())
+    {
+        ShowCursor(false);
+    }
+#endif
     // set blind parameters
     m_fBlindSpeed = ini->GetFloat(section, "BlindTime", 1.f);
     if (m_fBlindSpeed <= 0.0001f)

--- a/src/libs/xinterface/src/xinterface.cpp
+++ b/src/libs/xinterface/src/xinterface.cpp
@@ -1155,7 +1155,12 @@ void XINTERFACE::LoadIni()
     sscanf(param, "%[^,],%d,size:(%d,%d),pos:(%d,%d)", param2, &m_lMouseSensitive, &MouseSize.x, &MouseSize.y,
            &m_lXMouse, &m_lYMouse);
     m_idTex = pRenderService->TextureCreate(param2);
-    core.GetWindow()->WarpMouseInWindow(windowSize.width / 2, windowSize.height / 2);
+
+    if (auto *editor = core.GetEditor(); editor == nullptr || !editor->IsFocused())
+    {
+        core.GetWindow()->WarpMouseInWindow(windowSize.width / 2, windowSize.height / 2);
+    }
+
     fXMousePos = static_cast<float>(dwScreenWidth / 2);
     fYMousePos = static_cast<float>(dwScreenHeight / 2);
     for (int i = 0; i < 4; i++)
@@ -1164,9 +1169,6 @@ void XINTERFACE::LoadIni()
     vMouse[2].tu = vMouse[3].tu = 1.f;
     vMouse[0].tv = vMouse[2].tv = 0.f;
     vMouse[1].tv = vMouse[3].tv = 1.f;
-#ifdef _WIN32 // FIX_LINUX Cursor
-    ShowCursor(false);
-#endif
 
     // set blind parameters
     m_fBlindSpeed = ini->GetFloat(section, "BlindTime", 1.f);

--- a/src/libs/xinterface/src/xinterface.cpp
+++ b/src/libs/xinterface/src/xinterface.cpp
@@ -1169,12 +1169,7 @@ void XINTERFACE::LoadIni()
     vMouse[2].tu = vMouse[3].tu = 1.f;
     vMouse[0].tv = vMouse[2].tv = 0.f;
     vMouse[1].tv = vMouse[3].tv = 1.f;
-#ifdef _WIN32 // FIX_LINUX Cursor
-    if (auto *editor = core.GetEditor(); editor == nullptr || !editor->IsFocused())
-    {
-        ShowCursor(false);
-    }
-#endif
+    core.GetWindow()->ShowCursor(false);
     // set blind parameters
     m_fBlindSpeed = ini->GetFloat(section, "BlindTime", 1.f);
     if (m_fBlindSpeed <= 0.0001f)


### PR DESCRIPTION
Adds an in-game editor using imgui.

Editor can be enabled by adding the `--editor` flag to the engine cli arguments.

Replaces debug hotkeys with an editor menu. Also adds a tool for viewer all active entities and exposes controls for editing the properties of `SEA` entities.