### PR TITLE
Changed ifdef to use _WIN32 macro

### DIFF
--- a/src/libs/diagnostics/src/seh_extractor.cpp
+++ b/src/libs/diagnostics/src/seh_extractor.cpp
@@ -1,4 +1,4 @@
-#ifdef WIN32
+#ifdef _WIN32
 #include "seh_extractor.hpp"
 
 #include <exception>


### PR DESCRIPTION
Looks like `seh_extractor.cpp` is the only file that uses `#ifdef WIN32` while all other places use `#ifdef _WIN32`, and this caused linker errors when I tried to compile on local.

I compile the project manually from the command line instead of using Visual Studio, and maybe that's why I'm getting linker errors here, but all errors disappeared once I changed this line to  `#ifdef _WIN32`.