### PR TITLE
Fix wrong index in dialog vertex calculations

### DIFF
--- a/src/libs/dialog/src/dialog.cpp
+++ b/src/libs/dialog/src/dialog.cpp
@@ -45,7 +45,7 @@ inline void SetVerticesForSquare(XI_TEX_VERTEX *pV, FRECT uv, float left, float 
 
     pV[3].pos.x = right;
     pV[3].pos.y = bottom;
-    pV[2].pos.z = 1.f;
+    pV[3].pos.z = 1.f;
     pV[3].rhw = 0.5f;
     pV[3].color = 0xFFFFFFFF;
     pV[3].u = uv.right;


### PR DESCRIPTION
This bug leaves `pV[3].pos.z` uninitialized, causing half of the dialog background to be missing under certain conditions:
![img0000_cropped](https://github.com/user-attachments/assets/68595648-ccfe-43de-aee7-c94190f51c8f)

On Windows this seems to happen very rarely, but can be reliably reproduced by writing garbage to the vertex buffer in `DIALOG::FillBack` after locking it but before writing vertex values, like that:
```cpp
XI_TEX_VERTEX * pV = (XI_TEX_VERTEX*)RenderService->LockVertexBuffer( m_idVBufBack );
memset(pV, 0xff, m_nVQntBack * sizeof(XI_TEX_VERTEX)); // <--
// fill the vertex data with SetVerticesForSquare...
```