### PR TITLE
Allow setting a custom window title

### DIFF
--- a/src/apps/engine/src/main.cpp
+++ b/src/apps/engine/src/main.cpp
@@ -22,6 +22,7 @@ namespace
 CorePrivate *core_private;
 
 constexpr char defaultLoggerName[] = "system";
+constexpr const char *DEFAULT_WINDOW_TITLE = "Storm Engine";
 bool isRunning = false;
 bool bActive = true;
 bool bSoundInBackground = false;
@@ -238,18 +239,10 @@ int main(int argc, char *argv[])
 
     std::shared_ptr<storm::OSWindow> window =
         storm::OSWindow::Create(width, height, preferred_display, fullscreen, show_borders);
-    
-    char default_title[] = "Beyond New Horizons";
-    char title[256];
-    auto res = ini->ReadString(nullptr, "title", title, sizeof(title), "");
-    if (res)
-    {
-        window->SetTitle(title);
-    }
-    else
-    {
-        window->SetTitle(default_title);
-    }
+
+    char title[256]{};
+    ini->ReadString(nullptr, "title", title, sizeof(title), DEFAULT_WINDOW_TITLE);
+    window->SetTitle(title);
 
     window->Subscribe(HandleWindowEvent);
     window->Show();

--- a/src/apps/engine/src/main.cpp
+++ b/src/apps/engine/src/main.cpp
@@ -238,7 +238,19 @@ int main(int argc, char *argv[])
 
     std::shared_ptr<storm::OSWindow> window =
         storm::OSWindow::Create(width, height, preferred_display, fullscreen, show_borders);
-    window->SetTitle("Beyond New Horizons");
+    
+    char default_title[] = "Beyond New Horizons";
+    char title[256];
+    auto res = ini->ReadString(nullptr, "title", title, sizeof(title), "");
+    if (res)
+    {
+        window->SetTitle(title);
+    }
+    else
+    {
+        window->SetTitle(default_title);
+    }
+
     window->Subscribe(HandleWindowEvent);
     window->Show();
     core_private->SetWindow(window);


### PR DESCRIPTION
Add `title` option to `engine.ini` to allow settings a custom window title.

Default title has been changed to "Storm Engine".