### PR TITLE
Accommodating the old "jump" action

### DIFF
--- a/src/libs/location/src/character.cpp
+++ b/src/libs/location/src/character.cpp
@@ -2410,7 +2410,7 @@ void Character::Update(float dltTime)
         isSlide = ptc.isSlide;
         if (ptc.isSlide && isEnableJump)
         {
-            if (fall.name && !isFight && !priorityAction.name)
+            if (jump.name && !isFight && !priorityAction.name)
             {
                 if (TestJump(curPos + CVECTOR(0.001f * sinf(ay), -0.001f, 0.001f * cosf(ay))))
                 {
@@ -2420,7 +2420,7 @@ void Character::Update(float dltTime)
                     jumpSound = SOUND_INVALID_ID;
                     PlaySound("clothes");
                     if (fabsf(curPos.y - osculationPoint.y) > 1.5f)
-                        SetPriorityAction(fall.name);
+                        SetPriorityAction(jump.name);
                     return;
                 }
             }
@@ -4090,10 +4090,10 @@ void Character::UpdateAnimation()
             }
             else if (isJump)
             {
-                if (!SetAction(fall.name, fall.tblend, 0.0f, 0.0f))
+                /*if (!SetAction(fall.name, fall.tblend, 0.0f, 0.0f))
                 {
                     core.Trace("Character animation: not fall action: \"%s\"", fall.name);
-                }
+                }*/
             }
             else if (isMove)
             {


### PR DESCRIPTION
The engine refers to animated character actions like "fall", "fall_land" an "fall_water" - these do not exist in PotC character animation files. These new actions are used by the newer game(s).

The animation that is referred to in the engine as "fall" is defined as "jump" by PotC. (I believe "jump" might refer to another action in the newer games.)

Also, the newer game(s) seem(s) to have separate actions for falling, landing in water, and landing on land.

This inconsistency results in strange behaviour in Beyond New Horizons when falling.

To showcase this, in this PR I have some code that calls the "jump" action instead of "fall", and therefore falling from larger heights works as expected (falling from smaller heights is still strange). However, this likely breaks the same functionality of the newer game(s). Additional changes are required to accommodate both systems.