### PR TITLE
Use Node.js 20 for Sentry CLI uploads; remove clang-15 apt install from Linux CI

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -61,9 +61,9 @@ jobs:
         path: build/default/${{ matrix.configuration }}
         include-hidden-files: true
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '20'
     - name: Upload debug symbols
       if: env.SENTRY_AUTH_TOKEN
       env:

--- a/.github/workflows/release_beta.yml
+++ b/.github/workflows/release_beta.yml
@@ -51,9 +51,9 @@ jobs:
         draft: contains(github.ref, 'beta')
         files: storm-engine.${{ matrix.configuration }}-steam-${{ matrix.enable_steam }}.zip
     - name: Setup Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '20'
     - name: Upload debug symbols
       run: |
         npm install @sentry/cli


### PR DESCRIPTION
### Motivation
- `@sentry/cli` (and its dependency `undici`) requires Node >= 18 so Windows and beta workflows using Node 16 failed during `npm install` on the runner. 
- A previous change added `clang-15` to the Linux `apt-get install` list but review requested reverting that install modification. 

### Description
- Update `ci_windows.yml` to use `actions/setup-node@v4` with `node-version: '20'` so Sentry CLI can be installed and run in the Windows CI job. 
- Update `release_beta.yml` to use `actions/setup-node@v4` with `node-version: '20'` so beta release uploads use a compatible Node runtime. 
- Revert the addition of `clang-15` from the `apt-get install` line in `ci_linux.yml` so the Linux package list is unchanged. 

### Testing
- No automated tests were run because these are CI workflow changes only and the updated workflows will be validated by GitHub Actions when the PR is executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967da2c5704832fa908dc6aee95bd47)